### PR TITLE
Remove key and branch filter artefacts

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -13,7 +13,7 @@
     <condition property="_normalize-strip-keyref" value="true" else="false">
       <and>
         <not>
-          <isset property="keyref.skip"/>
+          <isset property="preprocess.keyref.skip"/>
         </not>
         <or>
           <istrue value="${normalize-strip-keyref}"/>
@@ -27,7 +27,7 @@
     <condition property="_normalize-strip-branch-filter" value="true" else="false">
       <and>
         <not>
-          <isset property="branch-filter.skip"/>
+          <isset property="preprocess.branch-filter.skip"/>
         </not>
         <or>
           <istrue value="${normalize-strip-branch-filter}"/>

--- a/build.xml
+++ b/build.xml
@@ -9,11 +9,26 @@
           depends="build-init,
                    preprocess">
     <makeurl property="output.dir.uri" file="${output.dir}"/>
+    <local name="_normalize-strip-keyref"/>
+    <condition property="_normalize-strip-keyref" value="true" else="false">
+      <and>
+        <not>
+          <isset property="keyref.skip"/>
+        </not>
+        <or>
+          <istrue value="${normalize-strip-keyref}"/>
+          <not>
+            <isset property="normalize-strip-keyref"/>
+          </not>
+        </or>
+      </and>
+    </condition>
     <!--pipeline message="Normalize DITA files" taskname="normalize"-->
       <xslt in="${dita.temp.dir}/.job.xml" out="${dita.temp.dir}/.job.xml.temp"
             style="${dita.plugin.org.dita.normalize.dir}/xsl/normalize.xsl"
             taskname="normalize">
         <param name="output.dir.uri" expression="${output.dir.uri}"/>
+        <param name="normalize-strip-keyref" expression="${_normalize-strip-keyref}"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
     <!--/pipeline-->

--- a/build.xml
+++ b/build.xml
@@ -23,12 +23,27 @@
         </or>
       </and>
     </condition>
+    <local name="_normalize-strip-branch-filter"/>
+    <condition property="_normalize-strip-branch-filter" value="true" else="false">
+      <and>
+        <not>
+          <isset property="branch-filter.skip"/>
+        </not>
+        <or>
+          <istrue value="${normalize-strip-branch-filter}"/>
+          <not>
+            <isset property="normalize-strip-branch-filter"/>
+          </not>
+        </or>
+      </and>
+    </condition>
     <!--pipeline message="Normalize DITA files" taskname="normalize"-->
       <xslt in="${dita.temp.dir}/.job.xml" out="${dita.temp.dir}/.job.xml.temp"
             style="${dita.plugin.org.dita.normalize.dir}/xsl/normalize.xsl"
             taskname="normalize">
         <param name="output.dir.uri" expression="${output.dir.uri}"/>
         <param name="normalize-strip-keyref" expression="${_normalize-strip-keyref}"/>
+        <param name="normalize-strip-branch-filter" expression="${_normalize-strip-branch-filter}"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
     <!--/pipeline-->

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,10 @@
       <val default="true">yes</val>
       <val>no</val>
     </param>
+    <param name="normalize-strip-branch-filter" desc="Remove branch filter artefacts after branch filter resolution." type="enum">
+      <val default="true">yes</val>
+      <val>no</val>
+    </param>
   </transtype>
   <feature extension="dita.conductor.target.relative" file="conductor.xml"/>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,6 +4,11 @@
   See the accompanying license.txt file for applicable licenses.
 -->
 <plugin id="org.dita.normalize">
-  <transtype name="dita" desc="Normalized DITA"/>
+  <transtype name="dita" desc="Normalized DITA">
+    <param name="normalize-strip-keyref" desc="Remove key artefacts after key resolution." type="enum">
+      <val default="true">yes</val>
+      <val>no</val>
+    </param>
+  </transtype>
   <feature extension="dita.conductor.target.relative" file="conductor.xml"/>
 </plugin>

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -143,6 +143,7 @@
                        processing-instruction('workdir-uri') |
                        processing-instruction('path2project') |
                        processing-instruction('path2project-uri') |
+                       processing-instruction('path2rootmap-uri') |
                        processing-instruction('ditaot') |
                        processing-instruction('doctype-public') |
                        processing-instruction('doctype-system') |

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -136,9 +136,11 @@
     </xsl:choose>
   </xsl:function>
 
+  <!-- Remove default attributes from schema -->
   <xsl:template match="@class | @domains | @specializations | @xtrf | @xtrc | @ditaarch:DITAArchVersion"
                 priority="10"/>
 
+  <!-- Remove processing time PIs -->
   <xsl:template match="processing-instruction('workdir') |
                        processing-instruction('workdir-uri') |
                        processing-instruction('path2project') |
@@ -151,8 +153,10 @@
                        @mapclass"
                 priority="10"/>
 
+  <!-- Remove cascade inserted by preprocess -->
   <xsl:template match="*[number(@ditaarch:DITAArchVersion) &lt; 1.3]/@cascade"/>
 
+  <!-- Rename elements to match class type -->
   <xsl:template match="*[@class]" priority="-5">
     <xsl:element name="{tokenize(tokenize(normalize-space(@class), '\s+')[last()], '/')[last()]}"
       namespace="{namespace-uri()}">
@@ -160,16 +164,20 @@
     </xsl:element>
   </xsl:template>
 
+  <!-- Remove resolved keydefs -->
   <xsl:template match="*[contains(@class, ' map/topicref ')]
                         [exists(@keys) and @processing-role = 'resource-only']
                         [$normalize-strip-keyref = 'true']"/>
 
+  <!-- Remove resolved key definition and references -->
   <xsl:template match="@keyref[$normalize-strip-keyref = 'true'] |
                        @keys[$normalize-strip-keyref = 'true']"/>
 
+  <!-- Remove resolved ditavalrefs -->
   <xsl:template match="*[contains(@class, ' ditavalref-d/ditavalref ')]
                         [$normalize-strip-branch-filter = 'true']"/>
 
+  <!-- Rewrite link target -->
   <xsl:template match="*[contains(@class, ' topic/xref ') or
                          contains(@class, ' topic/link ') or
                          (contains(@class, ' topic/keyword') and exists(@href)) or
@@ -195,6 +203,7 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- Rename keyword that has been converted into a link using keys -->
   <xsl:template match="*[contains(@class, ' topic/keyword ') and exists(@href)]">
     <xref>
       <xsl:apply-templates select="@*"/>
@@ -203,6 +212,7 @@
     </xref>
   </xsl:template>
 
+  <!-- Remove default attributes -->
   <xsl:template match="*[contains(@class, ' topic/pre ')]/@xml:space[. = 'preserve'] |
                        @scope[. = 'local'] |
                        @format[. = 'dita'] |
@@ -210,6 +220,7 @@
 
   <xsl:template match="*[contains(@class, ' subjectScheme/')]" priority="5"/>
 
+  <!-- Remove colname inserted by preprocess -->
   <xsl:template match="*[contains(@class, ' topic/entry ')]/@colname">
     <xsl:if test="empty(../@namest) and empty(../@nameend)">
       <xsl:copy-of select="."/>

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -171,7 +171,8 @@
                         [$normalize-strip-branch-filter = 'true']"/>
 
   <xsl:template match="*[contains(@class, ' topic/xref ') or
-                         contains(@class, ' topic/xref ') or
+                         contains(@class, ' topic/link ') or
+                         (contains(@class, ' topic/keyword') and exists(@href)) or
                          contains(@class, ' map/topicref ')]
                         [empty(@format) or @format = 'dita']
                         [empty(@scope) or @scope = 'local']/@href">
@@ -193,6 +194,21 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/keyword ') and exists(@href)]">
+    <xref>
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="class">- topic/xref </xsl:attribute>
+      <xsl:apply-templates select="node()"/>
+    </xref>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/pre ')]/@xml:space[. = 'preserve'] |
+                       @scope[. = 'local'] |
+                       @format[. = 'dita'] |
+                       *[contains(@class, ' topic/xref ')]/@locktitle"/>
+
+  <xsl:template match="*[contains(@class, ' subjectScheme/')]" priority="5"/>
 
   <xsl:template match="*[contains(@class, ' topic/entry ')]/@colname">
     <xsl:if test="empty(../@namest) and empty(../@nameend)">

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -15,6 +15,7 @@
 
   <xsl:param name="output.dir.uri" as="xs:string"/>
   <xsl:param name="normalize-strip-keyref" as="xs:string"/>
+  <xsl:param name="normalize-strip-branch-filter" as="xs:string"/>
 
   <xsl:function name="dita-ot:get-fragment" as="xs:string">
     <xsl:param name="input" as="xs:string"/>
@@ -164,6 +165,9 @@
 
   <xsl:template match="@keyref[$normalize-strip-keyref = 'true'] |
                        @keys[$normalize-strip-keyref = 'true']"/>
+
+  <xsl:template match="*[contains(@class, ' ditavalref-d/ditavalref ')]
+                        [$normalize-strip-branch-filter = 'true']"/>
 
   <xsl:template match="*[contains(@class, ' topic/xref ') or
                          contains(@class, ' topic/xref ') or

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -13,7 +13,8 @@
 
   <xsl:import href="plugin:org.dita.base:xsl/common/uri-utils.xsl"/>
 
-  <xsl:param name="output.dir.uri"/>
+  <xsl:param name="output.dir.uri" as="xs:string"/>
+  <xsl:param name="normalize-strip-keyref" as="xs:string"/>
 
   <xsl:function name="dita-ot:get-fragment" as="xs:string">
     <xsl:param name="input" as="xs:string"/>
@@ -156,6 +157,13 @@
       <xsl:apply-templates select="node() | @*"/>
     </xsl:element>
   </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' map/topicref ')]
+                        [exists(@keys) and @processing-role = 'resource-only']
+                        [$normalize-strip-keyref = 'true']"/>
+
+  <xsl:template match="@keyref[$normalize-strip-keyref = 'true'] |
+                       @keys[$normalize-strip-keyref = 'true']"/>
 
   <xsl:template match="*[contains(@class, ' topic/xref ') or
                          contains(@class, ' topic/xref ') or


### PR DESCRIPTION
## Description
Remove key artefacts like `@keys`, `@keyref` or `<keydef>` after key resolution, and `<ditavalref>` after branch filter resolution.

Removal can be controlled with properties

*  `normalize-strip-keyref = yes | no`
*  `normalize-strip-branch-filter = yes | no`

The both properties default to `yes`.

## Motivation and Context
Once keys have been resolved, artefacts of those keys may not be needed. DITAVAL references are redundant after branch filtering.

## How Has This Been Tested?
Manual testing.
## Type of Changes
- New feature _(non-breaking change which adds functionality)_

