### PR TITLE
Use map-first preprocessing for normalization

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,7 +10,7 @@ See the accompanying LICENSE file for applicable license.
 
   <target name="dita2dita"
           depends="build-init,
-                   preprocess">
+                   preprocess2">
     <makeurl property="output.dir.uri" file="${output.dir}"/>
     <local name="_normalize-strip-keyref"/>
     <condition property="_normalize-strip-keyref" value="true" else="false">

--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,7 @@ See the accompanying LICENSE file for applicable license.
         </or>
       </and>
     </condition>
-    <!--pipeline message="Normalize DITA files" taskname="normalize"-->
+    <pipeline message="Normalize DITA files" taskname="normalize">
       <xslt in="${dita.temp.dir}/.job.xml" out="${dita.temp.dir}/.job.xml.temp"
             style="${dita.plugin.org.dita.normalize.dir}/xsl/normalize.xsl"
             taskname="normalize">
@@ -49,7 +49,7 @@ See the accompanying LICENSE file for applicable license.
         <param name="normalize-strip-branch-filter" expression="${_normalize-strip-branch-filter}"/>
         <xmlcatalog refid="dita.catalog"/>
       </xslt>
-    <!--/pipeline-->
+    </pipeline>
     <delete file="${dita.temp.dir}/.job.xml.temp"/>
   </target>
   

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@ Copyright 2015 Jarno Elovirta
 
 See the accompanying LICENSE file for applicable license.
 -->
-<plugin id="org.dita.normalize" version="1.1.0">
+<plugin id="org.dita.normalize" version="2.0.0">
   <transtype name="dita" desc="Normalized DITA">
     <param name="normalize-strip-keyref" desc="Remove key artefacts after key resolution." type="enum">
       <val default="true">yes</val>

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -233,6 +233,9 @@ See the accompanying LICENSE file for applicable license.
       <xsl:copy-of select="."/>
     </xsl:if>
   </xsl:template>
+
+  <!-- Remove reltable bacause links have already been pushed to topics -->
+  <xsl:template match="*[contains(@class, ' map/reltable ')]"/>
   
   <xsl:template match="*" priority="-10">
     <xsl:element name="{name()}" namespace="{namespace-uri()}">

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -7,39 +7,39 @@ Copyright 2015 Jarno Elovirta
 See the accompanying LICENSE file for applicable license.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
-                xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                exclude-result-prefixes="xs ditaarch dita-ot xsi"
-                version="2.0">
-
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  exclude-result-prefixes="xs ditaarch dita-ot xsi"
+  version="2.0">
+  
   <xsl:import href="plugin:org.dita.base:xsl/common/uri-utils.xsl"/>
-
+  
   <xsl:param name="output.dir.uri" as="xs:string"/>
   <xsl:param name="normalize-strip-keyref" as="xs:string"/>
   <xsl:param name="normalize-strip-branch-filter" as="xs:string"/>
-
+  
   <xsl:function name="dita-ot:get-fragment" as="xs:string">
     <xsl:param name="input" as="xs:string"/>
     <xsl:sequence select="replace($input, '^[^#]+', '')"/>
   </xsl:function>
-
+  
   <xsl:function name="dita-ot:strip-fragment" as="xs:anyURI">
     <xsl:param name="input" as="xs:string"/>
     <xsl:sequence select="xs:anyURI(replace($input, '#.*$', ''))"/>
   </xsl:function>
-
+  
   <xsl:function name="dita-ot:set-fragment" as="xs:anyURI">
     <xsl:param name="path" as="xs:string"/>
     <xsl:param name="fragment" as="xs:string"/>
     <xsl:sequence select="xs:anyURI(concat($path, $fragment))"/>
   </xsl:function>
-
+  
   <xsl:variable name="files" as="document-node()">
     <xsl:variable name="rewritten" as="element()*">
       <xsl:for-each select="job/files/file[(@format = 'dita')
-        or (@format = 'ditamap' and (@input, @inputResource) = 'true')]">
+                                        or (@format = 'ditamap' and (@input, @inputResource) = 'true')]">
         <xsl:copy>
           <xsl:copy-of select="@*"/>
           <xsl:attribute name="uri" select="resolve-uri(@uri, base-uri($root))"/>
@@ -65,24 +65,27 @@ See the accompanying LICENSE file for applicable license.
           <xsl:copy>
             <xsl:copy-of select="@* except @renamed"/>
             <xsl:attribute name="result" select="replace(@result, '\.(\w+)$',
-                if (position() eq 1)
-                then '.$1'
-                else concat('-', position() - 1, '.$1'))"/>
+              if (position() eq 1)
+              then '.$1'
+              else concat('-', position() - 1, '.$1'))"/>
           </xsl:copy>
         </xsl:for-each>
       </xsl:for-each-group>
     </xsl:document>
   </xsl:variable>
-
+  
   <xsl:key name="file-uri" match="file" use="@uri"/>
-
+  
   <xsl:variable name="root" select="." as="document-node()"/>
-
+  
   <xsl:template match="/">
     <xsl:for-each select="$files/*">
       <xsl:variable name="input.uri" select="resolve-uri(@uri, base-uri($root))"/>
       <xsl:variable name="output.uri" select="concat($output.dir.uri, @result)"/>
-      <xsl:message select="concat('Writing ', $output.uri)"/>
+      <xsl:message>
+        <xsl:processing-instruction name="level" select="'INFO'"/>
+        <xsl:value-of select="concat('Writing ', $output.uri)"/>
+      </xsl:message>
       <xsl:for-each select="document($input.uri)">
         <xsl:choose>
           <xsl:when test="*/@xsi:noNamespaceSchemaLocation">
@@ -94,8 +97,8 @@ See the accompanying LICENSE file for applicable license.
           </xsl:when>
           <xsl:otherwise>
             <xsl:result-document href="{$output.uri}"
-                                 doctype-public="{dita-ot:get-doctype-public(.)}"
-                                 doctype-system="{dita-ot:get-doctype-system(.)}">
+              doctype-public="{dita-ot:get-doctype-public(.)}"
+              doctype-system="{dita-ot:get-doctype-system(.)}">
               <xsl:apply-templates>
                 <xsl:with-param name="uri" select="$input.uri" as="xs:anyURI" tunnel="yes"/>
               </xsl:apply-templates>
@@ -105,7 +108,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:for-each>
     </xsl:for-each>
   </xsl:template>
-
+  
   <xsl:function name="dita-ot:get-doctype-public">
     <xsl:param name="doc" as="document-node()"/>
     <xsl:choose>
@@ -126,7 +129,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
-
+  
   <xsl:function name="dita-ot:get-doctype-system">
     <xsl:param name="doc" as="document-node()"/>
     <xsl:choose>
@@ -139,27 +142,27 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
-
+  
   <!-- Remove default attributes from schema -->
   <xsl:template match="@class | @domains | @specializations | @xtrf | @xtrc | @ditaarch:DITAArchVersion"
-                priority="10"/>
-
+    priority="10"/>
+  
   <!-- Remove processing time PIs -->
   <xsl:template match="processing-instruction('workdir') |
-                       processing-instruction('workdir-uri') |
-                       processing-instruction('path2project') |
-                       processing-instruction('path2project-uri') |
-                       processing-instruction('path2rootmap-uri') |
-                       processing-instruction('ditaot') |
-                       processing-instruction('doctype-public') |
-                       processing-instruction('doctype-system') |
-                       @dita-ot:* |
-                       @mapclass"
-                priority="10"/>
-
+    processing-instruction('workdir-uri') |
+    processing-instruction('path2project') |
+    processing-instruction('path2project-uri') |
+    processing-instruction('path2rootmap-uri') |
+    processing-instruction('ditaot') |
+    processing-instruction('doctype-public') |
+    processing-instruction('doctype-system') |
+    @dita-ot:* |
+    @mapclass"
+    priority="10"/>
+  
   <!-- Remove cascade inserted by preprocess -->
   <xsl:template match="*[number(@ditaarch:DITAArchVersion) &lt; 1.3]/@cascade"/>
-
+  
   <!-- Rename elements to match class type -->
   <xsl:template match="*[@class]" priority="-5">
     <xsl:element name="{tokenize(tokenize(normalize-space(@class), '\s+')[last()], '/')[last()]}"
@@ -167,27 +170,27 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="node() | @*"/>
     </xsl:element>
   </xsl:template>
-
+  
   <!-- Remove resolved keydefs -->
   <xsl:template match="*[contains(@class, ' map/topicref ')]
-                        [exists(@keys) and @processing-role = 'resource-only']
-                        [$normalize-strip-keyref = 'true']"/>
-
+    [exists(@keys) and @processing-role = 'resource-only']
+    [$normalize-strip-keyref = 'true']"/>
+  
   <!-- Remove resolved key definition and references -->
   <xsl:template match="@keyref[$normalize-strip-keyref = 'true'] |
-                       @keys[$normalize-strip-keyref = 'true']"/>
-
+    @keys[$normalize-strip-keyref = 'true']"/>
+  
   <!-- Remove resolved ditavalrefs -->
   <xsl:template match="*[contains(@class, ' ditavalref-d/ditavalref ')]
-                        [$normalize-strip-branch-filter = 'true']"/>
-
+    [$normalize-strip-branch-filter = 'true']"/>
+  
   <!-- Rewrite link target -->
   <xsl:template match="*[contains(@class, ' topic/xref ') or
-                         contains(@class, ' topic/link ') or
-                         (contains(@class, ' topic/keyword') and exists(@href)) or
-                         contains(@class, ' map/topicref ')]
-                        [empty(@format) or @format = 'dita']
-                        [empty(@scope) or @scope = 'local']/@href">
+    contains(@class, ' topic/link ') or
+    (contains(@class, ' topic/keyword') and exists(@href)) or
+    contains(@class, ' map/topicref ')]
+    [empty(@format) or @format = 'dita']
+    [empty(@scope) or @scope = 'local']/@href">
     <xsl:param name="uri" as="xs:anyURI" tunnel="yes"/>
     <xsl:variable name="input" select="resolve-uri(., $uri)" as="xs:string"/>
     <xsl:variable name="path" select="dita-ot:strip-fragment($input)" as="xs:anyURI"/>
@@ -197,8 +200,8 @@ See the accompanying LICENSE file for applicable license.
       <xsl:when test="exists($href)">
         <xsl:attribute name="{name()}" select="dita-ot:set-fragment(
           dita-ot:relativize(
-            resolve-uri('.',$uri),
-            resolve-uri($href, base-uri($root))),
+          resolve-uri('.',$uri),
+          resolve-uri($href, base-uri($root))),
           $fragment)"/>
       </xsl:when>
       <xsl:otherwise>
@@ -206,7 +209,7 @@ See the accompanying LICENSE file for applicable license.
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-
+  
   <!-- Rename keyword that has been converted into a link using keys -->
   <xsl:template match="*[contains(@class, ' topic/keyword ') and exists(@href)]">
     <xref>
@@ -215,32 +218,32 @@ See the accompanying LICENSE file for applicable license.
       <xsl:apply-templates select="node()"/>
     </xref>
   </xsl:template>
-
+  
   <!-- Remove default attributes -->
   <xsl:template match="*[contains(@class, ' topic/pre ')]/@xml:space[. = 'preserve'] |
-                       @scope[. = 'local'] |
-                       @format[. = 'dita'] |
-                       *[contains(@class, ' topic/xref ')]/@locktitle"/>
-
+    @scope[. = 'local'] |
+    @format[. = 'dita'] |
+    *[contains(@class, ' topic/xref ')]/@locktitle"/>
+  
   <xsl:template match="*[contains(@class, ' subjectScheme/')]" priority="5"/>
-
+  
   <!-- Remove colname inserted by preprocess -->
   <xsl:template match="*[contains(@class, ' topic/entry ')]/@colname">
     <xsl:if test="empty(../@namest) and empty(../@nameend)">
       <xsl:copy-of select="."/>
     </xsl:if>
   </xsl:template>
-
+  
   <xsl:template match="*" priority="-10">
     <xsl:element name="{name()}" namespace="{namespace-uri()}">
       <xsl:apply-templates select="node() | @*"/>
     </xsl:element>
   </xsl:template>
-
+  
   <xsl:template match="node() | @*" priority="-15">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>
     </xsl:copy>
   </xsl:template>
-
+  
 </xsl:stylesheet>

--- a/xsl/normalize.xsl
+++ b/xsl/normalize.xsl
@@ -38,7 +38,8 @@ See the accompanying LICENSE file for applicable license.
 
   <xsl:variable name="files" as="document-node()">
     <xsl:variable name="rewritten" as="element()*">
-      <xsl:for-each select="job/files/file[@format = ('dita', 'ditamap')]">
+      <xsl:for-each select="job/files/file[(@format = 'dita')
+        or (@format = 'ditamap' and (@input, @inputResource) = 'true')]">
         <xsl:copy>
           <xsl:copy-of select="@*"/>
           <xsl:attribute name="uri" select="resolve-uri(@uri, base-uri($root))"/>


### PR DESCRIPTION
## Description
Use map-first preprocessing (`preprocess2`).

## Motivation and Context
DITA-OT 4.2 moves HTML5 to use map-first preprocessing, making map-first preprocessing the default in built-in transtype. The normalize plug-in should follow this.

## How Has This Been Tested?
Manual testing.

## Type of Changes
- New feature _(non-breaking change which adds functionality)_

## Documentation and Compatibility
Release notes should state that DITA output now also uses map-first preprocessing. If uses need to revert back to legacy preprocessing, they should uninstall bundled `org.dita.normalize` and reinstall version `1.1.0` from from plug-in registry.
